### PR TITLE
Rename thread_local -> threadvar and alignof -> AlignOf

### DIFF
--- a/OS/Win32/os_core_win32.c
+++ b/OS/Win32/os_core_win32.c
@@ -319,10 +319,10 @@ w32_entry_point_caller(int argc, WCHAR **wargv)
   Arena *args_arena = ArenaBuild();
   CmdLine *cmdln = New(args_arena, CmdLine);
   cmdln->count = argc - 1;
-  cmdln->exe = UTF8From16(args_arena, str16_cstr(wargv[0]));
+  cmdln->exe = UTF8From16(args_arena, str16_cstr((u16*)wargv[0]));
   for(int i = 1; i < argc; ++i)
   {
-    cmdln->args[i - 1] = UTF8From16(args_arena, str16_cstr(wargv[i]));
+    cmdln->args[i - 1] = UTF8From16(args_arena, str16_cstr((u16*)wargv[i]));
   }
   
   start(cmdln);

--- a/base/arena.h
+++ b/base/arena.h
@@ -9,8 +9,8 @@
 
 #define New(...) Newx(__VA_ARGS__,New3,New2)(__VA_ARGS__)
 #define Newx(a,b,c,d,...) d
-#define New2(arenaptr, type) (type*)arenaPush(arenaptr, sizeof(type), alignof(type))
-#define New3(arenaptr, type, count) (type*)arenaPush(arenaptr, (count) * sizeof(type), alignof(type))
+#define New2(arenaptr, type) (type*)arenaPush(arenaptr, sizeof(type), AlignOf(type))
+#define New3(arenaptr, type, count) (type*)arenaPush(arenaptr, (count) * sizeof(type), AlignOf(type))
 
 #define ArenaDefaultReserveSize MB(4)
 #define ArenaDefaultCommitSize KiB(4)

--- a/base/base.h
+++ b/base/base.h
@@ -100,19 +100,19 @@
 #define TLS_CTX_SIZE MB(64)
 
 #if COMPILER_GCC
-#  define alignof(TYPE) __alignof__(TYPE)
+#  define AlignOf(TYPE) __alignof__(TYPE)
 #elif COMPILER_CLANG
-#  define alignof(TYPE) _Alignof(TYPE)
+#  define AlignOf(TYPE) _Alignof(TYPE)
 #elif COMPILER_CL
-#  define alignof(TYPE) __alignof(TYPE)
+#  define AlignOf(TYPE) __alignof(TYPE)
 #else
-#  define alignof(TYPE) 1
+#  define AlignOf(TYPE) 1
 #endif
 
 #if COMPILER_CL
-#  define thread_local __declspec(thread)
+#  define threadvar __declspec(thread)
 #elif COMPILER_CLANG || COMPILER_GCC
-#  define thread_local __thread
+#  define threadvar __thread
 #endif
 
 

--- a/base/thread_ctx.c
+++ b/base/thread_ctx.c
@@ -1,4 +1,4 @@
-global thread_local TlsContext tls_ctx;
+global threadvar TlsContext tls_ctx;
 
 fn Arena *tlsGetScratch(Arena **conflicts, usize count) {
   if(tls_ctx.arenas[0] == 0) {

--- a/serializer/csv.h
+++ b/serializer/csv.h
@@ -4,8 +4,8 @@
 typedef struct {
   char delimiter;
   File file;
-
-  usize offset;
+  
+  isize offset;
 } CSV;
 
 fn StringStream csv_header(Arena *arena, CSV *config);


### PR DESCRIPTION
thread_local and alignof are keyword that are already taken in cpp and Windows runtime doesn't allow you to redefine them.