### PR TITLE
change time conversion to a mixed radix system

### DIFF
--- a/OS/core/Linux/linux_core.c
+++ b/OS/core/Linux/linux_core.c
@@ -118,8 +118,9 @@ fn void lnx_parseMeminfo(void) {
   }
 }
 
-fn DateTime lnx_date_time_from_tm(struct tm *tm){
+fn DateTime lnx_date_time_from_tm(struct tm *tm, long msec){
   DateTime r = {0};
+  r.ms = msec;
   r.second = tm->tm_sec;
   r.minute = tm->tm_min;
   r.hour = tm->tm_hour;
@@ -150,13 +151,13 @@ fn OS_SystemInfo *os_getSystemInfo(void) {
 // DateTime
 
 fn DateTime os_utc_now(void) {
-  time_t t = 0;
-  
-  time(&t);
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  time_t t = ts.tv_sec;
   struct tm tm;
   gmtime_r(&t, &tm);
   // NOTE(km): find a way to retrieve milliseconds
-  DateTime r = lnx_date_time_from_tm(&tm);
+  DateTime r = lnx_date_time_from_tm(&tm, ts.tv_nsec / Million(1));
   return r;
 }
 
@@ -172,7 +173,7 @@ fn DateTime os_utc_from_local_time(DateTime *dt){
   time_t t = mktime(&tm_local);
   struct tm tm_utc;
   gmtime_r(&t, &tm_utc);
-  DateTime r = lnx_date_time_from_tm(&tm_utc);
+  DateTime r = lnx_date_time_from_tm(&tm_utc, dt->ms);
   return r;
 }
 
@@ -182,7 +183,7 @@ fn DateTime os_local_from_utc_time(DateTime *dt) {
   time_t t = timegm(&tm_utc);
   struct tm tm_local;
   localtime_r(&t, &tm_local);
-  DateTime r = lnx_date_time_from_tm(&tm_local);
+  DateTime r = lnx_date_time_from_tm(&tm_local, dt->ms);
   return r;
 }
 

--- a/OS/core/Linux/linux_core.c
+++ b/OS/core/Linux/linux_core.c
@@ -118,6 +118,28 @@ fn void lnx_parseMeminfo(void) {
   }
 }
 
+fn DateTime lnx_date_time_from_tm(struct tm *tm){
+  DateTime r = {0};
+  r.second = tm->tm_sec;
+  r.minute = tm->tm_min;
+  r.hour = tm->tm_hour;
+  r.day = tm->tm_mday;
+  r.month = tm->tm_mon+1;
+  r.year = tm->tm_year+1900;
+  return r;
+}
+
+fn struct tm lnx_tm_from_date_time(DateTime *in){
+  struct tm r = {0};
+  r.tm_sec = in->second;
+  r.tm_min = in->minute;
+  r.tm_hour = in->hour;
+  r.tm_mday = in->day;
+  r.tm_mon = in->month-1;
+  r.tm_year = in->year-1900;
+  return r;
+}
+
 // =============================================================================
 // System information retrieval
 fn OS_SystemInfo *os_getSystemInfo(void) {
@@ -126,84 +148,42 @@ fn OS_SystemInfo *os_getSystemInfo(void) {
 
 // =============================================================================
 // DateTime
-fn time64 os_local_now(void) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
 
-  time64 res = time64_from_unix(tms.tv_sec + lnx_state.unix_utc_offset);
-  res |= (u64)(tms.tv_nsec / 1e6);
-  return res;
+fn DateTime os_utc_now(void) {
+  time_t t = 0;
+  
+  time(&t);
+  struct tm tm;
+  gmtime_r(&t, &tm);
+  // NOTE(km): find a way to retrieve milliseconds
+  DateTime r = lnx_date_time_from_tm(&tm);
+  return r;
 }
 
-fn DateTime os_local_dateTimeNow(void) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
-
-  DateTime res = datetime_from_unix(tms.tv_sec + lnx_state.unix_utc_offset);
-  res.ms = tms.tv_nsec / 1e6;
-  return res;
+fn u64 os_unix_now(){
+  time_t t = time(0);
+  return (u64)t;
+  
 }
 
-fn time64 os_local_fromUTCTime64(time64 t) {
-  u64 utc_time = unix_from_time64(t);
-  time64 res = time64_from_unix(utc_time + lnx_state.unix_utc_offset);
-  return res | (t & bitmask10);
+fn DateTime os_utc_from_local_time(DateTime *dt){
+  struct tm tm_local = lnx_tm_from_date_time(dt);
+  tm_local.tm_isdst = -1;
+  time_t t = mktime(&tm_local);
+  struct tm tm_utc;
+  gmtime_r(&t, &tm_utc);
+  DateTime r = lnx_date_time_from_tm(&tm_utc);
+  return r;
 }
 
-fn DateTime os_local_fromUTCDateTime(DateTime *dt) {
-  u64 utc_time = unix_from_datetime(dt);
-  DateTime res = datetime_from_unix(utc_time + lnx_state.unix_utc_offset);
-  res.ms = dt->ms;
-  return res;
-}
-
-fn time64 os_utc_now(void) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
-
-  time64 res = time64_from_unix(tms.tv_sec);
-  res |= (u64)(tms.tv_nsec / 1e6);
-  return res;
-}
-
-fn DateTime os_utc_dateTimeNow(void) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
-
-  DateTime res = datetime_from_unix(tms.tv_sec);
-  res.ms = tms.tv_nsec / 1e6;
-  return res;
-}
-
-fn time64 os_utc_localizedTime64(i8 utc_offset) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
-
-  time64 res = time64_from_unix(tms.tv_sec + utc_offset * UNIX_HOUR);
-  res |= (u64)(tms.tv_nsec / 1e6);
-  return res;
-}
-
-fn DateTime os_utc_localizedDateTime(i8 utc_offset) {
-  struct timespec tms;
-  (void)clock_gettime(CLOCK_REALTIME, &tms);
-
-  DateTime res = datetime_from_unix(tms.tv_sec + utc_offset * UNIX_HOUR);
-  res.ms = tms.tv_nsec / 1e6;
-  return res;
-}
-
-fn time64 os_utc_fromLocalTime64(time64 t) {
-  u64 local_time = unix_from_time64(t);
-  time64 res = time64_from_unix(local_time - lnx_state.unix_utc_offset);
-  return res | (t & bitmask10);
-}
-
-fn DateTime os_utc_fromLocalDateTime(DateTime *dt) {
-  u64 local_time = unix_from_datetime(dt);
-  DateTime res = datetime_from_unix(local_time - lnx_state.unix_utc_offset);
-  res.ms = dt->ms;
-  return res;
+fn DateTime os_local_from_utc_time(DateTime *dt) {
+  struct tm tm_utc = lnx_tm_from_date_time(dt);
+  tm_utc.tm_isdst = -1;
+  time_t t = timegm(&tm_utc);
+  struct tm tm_local;
+  localtime_r(&t, &tm_local);
+  DateTime r = lnx_date_time_from_tm(&tm_local);
+  return r;
 }
 
 fn void os_sleep_milliseconds(u32 ms) {

--- a/OS/core/Linux/linux_core.h
+++ b/OS/core/Linux/linux_core.h
@@ -120,6 +120,6 @@ fn void lnx_sched_set_deadline(u64 runtime_ns, u64 deadline_ns, u64 period_ns,
                                SignalFunc *deadline_miss_handler);
 fn void lnx_sched_yield(void);
 
-fn DateTime lnx_date_time_from_tm(struct tm *tm);
+fn DateTime lnx_date_time_from_tm(struct tm *tm, long msec);
 fn struct tm lnx_tm_from_date_time(DateTime *in);
 #endif

--- a/OS/core/Linux/linux_core.h
+++ b/OS/core/Linux/linux_core.h
@@ -120,4 +120,6 @@ fn void lnx_sched_set_deadline(u64 runtime_ns, u64 deadline_ns, u64 period_ns,
                                SignalFunc *deadline_miss_handler);
 fn void lnx_sched_yield(void);
 
+fn DateTime lnx_date_time_from_tm(struct tm *tm);
+fn struct tm lnx_tm_from_date_time(DateTime *in);
 #endif

--- a/OS/core/os_core.c
+++ b/OS/core/os_core.c
@@ -49,3 +49,72 @@ inline fn bool os_timer_elapsed_time(OS_TimerGranularity unit, OS_Handle timer,
   os_timer_free(now);
   return elapsed >= how_much;
 }
+
+fn time64 os_local_now(){
+  DateTime now = os_utc_now();
+  DateTime local_time = os_local_from_utc_time(&now);
+  time64 result = time64_from_datetime(&local_time);
+  return result;
+}
+
+fn DateTime os_local_date_time_now(){
+  DateTime now = os_utc_now();
+  DateTime local_time = os_local_from_utc_time(&now);
+  return local_time;
+}
+
+fn time64 os_local_from_utc_time64(time64 t){
+  DateTime date_time = datetime_from_time64(t);
+  DateTime local_time = os_local_from_utc_time(&date_time);
+  time64 result = time64_from_datetime(&local_time);
+  return result;
+}
+
+fn time64 os_utc_time64_now(){
+  DateTime date_time = os_utc_now();
+  time64 result = time64_from_datetime(&date_time);
+  return result;
+}
+
+fn DateTime os_utc_localized_date_time(i8 utc_offset) {
+  DateTime res = os_utc_now();
+  res.hour += utc_offset;
+  if (res.hour < 0) {
+    res.day -= 1;
+    res.hour += 24;
+  } else if (res.hour > 23) {
+    res.day += 1;
+    res.hour -= 24;
+  }
+  
+  if (res.day < 1) {
+    res.month -= 1;
+    res.day = days_per_month[res.month - 1];
+  } else if (res.day > days_per_month[res.month - 1]) {
+    res.month += 1;
+    res.day = 1;
+  }
+  
+  if (res.month < 1) {
+    res.year -= 1;
+    res.month = 12;
+  } else if (res.month > 12) {
+    res.year += 1;
+    res.month = 1;
+  }
+  
+  return res;
+}
+
+fn time64 os_utc_localized_time64(i8 utc_offset){
+  DateTime date_time = os_utc_localized_date_time(utc_offset);
+  time64 result = time64_from_datetime(&date_time);
+  return result;
+}
+
+fn time64 os_utc_from_local_time64(time64 t){
+  DateTime date_time = datetime_from_time64(t);
+  DateTime local_time = os_local_from_utc_time(&date_time);
+  time64 result = time64_from_datetime(&local_time);
+  return result;
+}

--- a/OS/core/os_core.h
+++ b/OS/core/os_core.h
@@ -181,17 +181,19 @@ fn OS_SystemInfo *os_getSystemInfo(void);
 
 // =============================================================================
 // DateTime
-fn time64 os_local_now(void);
-fn DateTime os_local_dateTimeNow(void);
-fn time64 os_local_fromUTCTime64(time64 t);
-fn DateTime os_local_fromUTCDateTime(DateTime *dt);
 
-fn time64 os_utc_now(void);
-fn DateTime os_utc_dateTimeNow(void);
-fn time64 os_utc_localizedTime64(i8 utc_offset);
-fn DateTime os_utc_localizedDateTime(i8 utc_offset);
-fn time64 os_utc_fromLocalTime64(time64 t);
-fn DateTime os_utc_fromLocalDateTime(DateTime *dt);
+fn DateTime os_utc_now();
+fn time64 os_utc_time64_now();
+fn u64 os_unix_now();
+fn DateTime os_utc_from_local_time(DateTime *local_time);
+fn DateTime os_local_from_utc_time(DateTime *utc_time);
+
+fn time64 os_local_now();
+fn DateTime os_local_date_time_now();
+fn time64 os_local_from_utc_time64(time64 t);
+fn DateTime os_utc_localized_date_time(i8 utc_offset);
+fn time64 os_utc_localized_time64(i8 utc_offset);
+fn time64 os_utc_from_local_time64(time64 t);
 
 fn void os_sleep_milliseconds(u32 ms);
 

--- a/base/base.h
+++ b/base/base.h
@@ -215,6 +215,7 @@
 
 #define Thousand(x) ((x)*1000)
 #define Million(x)  ((x)*1000000ull)
+#define Billion(x)  ((x)*1000000000ull)
 
 #define global static
 #define local static

--- a/base/time.c
+++ b/base/time.c
@@ -4,113 +4,75 @@ inline fn bool is_leap_year(u32 year) {
 }
 
 fn DateTime datetime_from_time64(time64 t) {
-  DateTime res = {0};
-  res.ms     = (u16)(t & bitmask10);
-  res.second = (u8)((t >> 10) & bitmask6);
-  res.minute = (u8)((t >> 16) & bitmask6);
-  res.hour   = (u8)((t >> 22) & bitmask5);
-  res.day    = (u8)((t >> 27) & bitmask5);
-  res.month  = (u8)((t >> 32) & bitmask4);
-  res.year   = ((t >> 36) & ~bit28) * (t >> 63 ? 1 : -1);
-  return res;
+  DateTime r = {0};
+  r.ms = t % 1000;
+  t /= 1000;
+  r.second = t%61;
+  t /= 61;
+  r.minute = t%60;
+  t /= 60;
+  r.hour = t%24;
+  t /= 24;
+  r.day = t%31 + 1;
+  t /= 31;
+  r.month = t%12 + 1;
+  t /= 12;
+  r.year = (i32)t;
+  return r;
+}
+
+fn time64 time64_from_datetime(DateTime *dt) {
+  time64 r = 0;
+  r += dt->year;
+  r *= 12;
+  r += dt->month - 1;
+  r *= 31;
+  r += dt->day - 1;
+  r *= 24;
+  r += dt->hour;
+  r *= 60;
+  r += dt->minute;
+  r *= 61;
+  r += dt->second;
+  r *= 1000;
+  r += dt->ms;
+  return r;
 }
 
 fn DateTime datetime_from_unix(u64 timestamp) {
   DateTime dt = {.year = 1970, .month = 1, .day = 1};
-
-  for (u64 secondsXyear = is_leap_year(dt.year)
-                          ? UNIX_LEAP_YEAR
-                          : UNIX_YEAR;
-       timestamp >= secondsXyear;
-       ++dt.year, timestamp -= secondsXyear,
-                  secondsXyear = is_leap_year(dt.year)
-                                 ? UNIX_LEAP_YEAR
-                                 : UNIX_YEAR);
-
+  
+  for (;;){
+    u64 seconds_per_year = is_leap_year(dt.year) ? UNIX_LEAP_YEAR : UNIX_YEAR;
+    if(timestamp < seconds_per_year) break;
+    dt.year += 1;
+    timestamp -= seconds_per_year;
+    seconds_per_year = is_leap_year(dt.year) ? UNIX_LEAP_YEAR : UNIX_YEAR;
+  }
+  
   while (1) {
-    u8 days = daysXmonth[dt.month - 1];
+    u8 days = days_per_month[dt.month - 1];
     if (dt.month == 2 && is_leap_year(dt.year)) {
       ++days;
     }
-
-    u64 secondsXmonth = days * UNIX_DAY;
-    if (timestamp < secondsXmonth) {
+    
+    u64 seconds_per_month = days * UNIX_DAY;
+    if (timestamp < seconds_per_month) {
       break;
     }
-
-    timestamp -= secondsXmonth;
+    
+    timestamp -= seconds_per_month;
     ++dt.month;
   }
-
+  
   dt.day += (u8)(timestamp / UNIX_DAY);
   timestamp %= UNIX_DAY;
-
   dt.hour = (u8)(timestamp / UNIX_HOUR);
   timestamp %= UNIX_HOUR;
-
   dt.minute = (u8)(timestamp / UNIX_MINUTE);
   timestamp %= UNIX_MINUTE;
-
   dt.second = (u8)timestamp;
-
   return dt;
-}
-
-fn time64 time64_from_datetime(DateTime *dt) {
-  time64 res = (dt->year >= 0 ? 1ULL << 63 : 0);
-  res |= (u64)((dt->year >= 0 ? dt->year : -dt->year) & ~bit28) << 36;
-  res |= (u64)(dt->month) << 32;
-  res |= (u64)(dt->day) << 27;
-  res |= (u64)(dt->hour) << 22;
-  res |= (u64)(dt->minute) << 16;
-  res |= (u64)(dt->second) << 10;
-  res |= (u64)dt->ms;
-  return res;
-}
-
-fn time64 time64_from_unix(u64 timestamp) {
-  time64 res = 1ULL << 63;
-
-  u32 year = 1970;
-  for (u64 secondsXyear = is_leap_year(year)
-                          ? UNIX_LEAP_YEAR
-                          : UNIX_YEAR;
-       timestamp >= secondsXyear;
-       ++year, timestamp -= secondsXyear,
-               secondsXyear = is_leap_year(year)
-                              ? UNIX_LEAP_YEAR
-                              : UNIX_YEAR);
-
-  res |= ((u64)year & ~(1 << 27)) << 36;
-  u64 month = 1;
-  while (1) {
-    u8 days = daysXmonth[month - 1];
-    if (month == 2 && is_leap_year(year)) {
-      ++days;
-    }
-
-    u64 secondsXmonth = days * UNIX_DAY;
-    if (timestamp < secondsXmonth) {
-      break;
-    }
-
-    timestamp -= secondsXmonth;
-    ++month;
-  }
-  res |= month << 32;
-
-  res |= (timestamp / UNIX_DAY + 1) << 27;
-  timestamp %= UNIX_DAY;
-
-  res |= (timestamp / UNIX_HOUR) << 22;
-  timestamp %= UNIX_HOUR;
-
-  res |= (timestamp / UNIX_MINUTE) << 16;
-  timestamp %= UNIX_MINUTE;
-
-  res |= timestamp << 10;
-
-  return res;
 }
 
 fn u64 unix_from_datetime(DateTime *dt) {
@@ -123,38 +85,24 @@ fn u64 unix_from_datetime(DateTime *dt) {
   for (u32 year = 1970; year < (u32)dt->year; ++year) {
     unix_time += is_leap_year(year) ? UNIX_LEAP_YEAR : UNIX_YEAR;
   }
-
+  
   for (u8 month = 1; month < dt->month; ++month) {
-    unix_time += daysXmonth[month - 1] * UNIX_DAY;
+    unix_time += days_per_month[month - 1] * UNIX_DAY;
     if (month == 2 && is_leap_year(dt->year)) {
       unix_time += UNIX_DAY;
     }
   }
-
-  return unix_time;
 }
 
-fn u64 unix_from_time64(time64 timestamp) {
-  u64 res = 0;
-  if (!(timestamp >> 63)) { return 0; }
 
-  i32 year = ((timestamp >> 36) & ~(1 << 27));
-  if (year < 1970) { return 0; }
-  for (i32 i = 1970; i < year; ++i) {
-    res += is_leap_year(i) ? UNIX_LEAP_YEAR : UNIX_YEAR;
-  }
+fn time64 time64_from_unix(u64 timestamp){
+  DateTime date_time = datetime_from_unix(timestamp);
+  time64 result = time64_from_datetime(&date_time);
+  return result;
+}
 
-  u8 time_month = (u8)((timestamp >> 32) & bitmask4);
-  for (u8 month = 1; month < time_month; ++month) {
-    res += daysXmonth[month - 1] * UNIX_DAY;
-    if (month == 2 && is_leap_year(year)) {
-      res += UNIX_DAY;
-    }
-  }
-
-  res += (((timestamp >> 27) & bitmask5) - 1) * UNIX_DAY;
-  res += ((timestamp >> 22) & bitmask5) * UNIX_HOUR;
-  res += ((timestamp >> 16) & bitmask6) * UNIX_MINUTE;
-  res += (timestamp >> 10) & bitmask6;
-  return res;
+fn u64 unix_from_time64(time64 timestamp){
+  DateTime date_time = datetime_from_time64(timestamp);
+  u64 result = unix_from_datetime(&date_time);
+  return result;
 }

--- a/base/time.h
+++ b/base/time.h
@@ -21,19 +21,19 @@ typedef u64 time64;
 #define UNIX_YEAR 31536000
 #define UNIX_LEAP_YEAR 31622400
 
-global const u8 daysXmonth[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+global const u8 days_per_month[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 inline fn bool is_leap_year(u32 year);
 
 // =============================================================================
 // Time format conversions
 fn DateTime datetime_from_time64(time64 timestamp);
-fn DateTime datetime_from_unix(u64 timestamp);
-
 fn time64 time64_from_datetime(DateTime *dt);
-fn time64 time64_from_unix(u64 timestamp);
 
+fn DateTime datetime_from_unix(u64 timestamp);
 fn u64 unix_from_datetime(DateTime *dt);
+
+fn time64 time64_from_unix(u64 timestamp);
 fn u64 unix_from_time64(time64 timestamp);
 
 #define TimedScope                                                           \


### PR DESCRIPTION
I put some of the functions to `os_core.c` and make them os independent. One of the things mr4th said is his video is that a good os layer have thin a abstraction layer, by having a thin layer you make the port to another OS much easier.  This is why i put some of the time functions in `os_core.c`. In the abstraction layer it is better to just declare function that are building block and they should cover for the general use case. If you need more specific case, you can create a function that uses those building blocks.
